### PR TITLE
Add default robots.txt file

### DIFF
--- a/_includes/layouts/base.liquid
+++ b/_includes/layouts/base.liquid
@@ -58,6 +58,9 @@
             <a href="https://www.11ty.dev/docs/config/">configuration preferences</a>.</li>
           <li>Delete this message from
             <code>_includes/layouts/base.liquid</code>.</li>
+          <li>(Optional) Adjust
+            <code>robots.txt</code>
+            to your preferences.</li>
         </ol>
       </div>
       <!-- Stop deleting -->

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -8,7 +8,8 @@
 
 /** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
 module.exports = function(eleventyConfig) {
-		// Copy `img` and `css` folders to output
+		// Copy `img` and `css` folders and robots.txt file to output
 		eleventyConfig.addPassthroughCopy("img");
 		eleventyConfig.addPassthroughCopy("css");
+		eleventyConfig.addPassthroughCopy("robots.txt");
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,79 @@
+#################################
+# The robots.txt file
+#################################
+#  
+# Robots are programs that crawl a page to use its content in some other way.
+# The most common reasons for this are search engines, who want to make the site
+# searchable, and AI-Models, who use the Data as part of their training.
+# 
+# This file sets up rules stating which robots can and cannot crawl which parts
+# of the site. However, this file is more of a sign, which simply asks robots to
+# respect the rules. It cannot enforce them.
+# 
+# The basic syntax is simple: You start with a User-Agent,
+# which specifies to which bot the following rules apply to.
+# You can then set "Disallow" Directives, one per row.
+# Lines that start with a '#' are ignored.
+# 
+# By default, this file excludes all Bots from crawling images (the ones in the
+# "img"-folder) and excludes common AI models completely.
+# Please note that preventing search engines from crawling the "/img" folder
+# will also prevent them from finding the page via a reverse image search. 
+# 
+# You may adjust your preferences.
+#
+
+
+#################################
+# Section for Search Engines.
+#################################
+
+# Is handled by the "Every other robot" Part at the bottom.
+
+#################################
+# Section for AI Systems.
+#################################
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+#################################
+# Section for Generic Crawlers
+#################################
+# 
+# These Companies may sell crawled data, so it may be used for search engines
+# and AI-Training Models.
+# 
+
+User-agent: Omgili
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+#################################
+# Every other robot.
+#################################
+
+# Disallow the crawling of images.
+# Note: This will prevent reverse image searches from finding the page. 
+User-agent: *
+Disallow: /img/


### PR DESCRIPTION
I think having a robots.txt file would benefit most websites, and people without experience in web development may not know that this standard exists.

I chose defaults I considered strict, but reasonable. While I don't assume many people would like to exclude the `/img` folder from search engines, I think it's just a bit easier to remove this directive than to add it.